### PR TITLE
Fixed hyphen-used-as-minus-sign in gmqcc.1

### DIFF
--- a/doc/gmqcc.1
+++ b/doc/gmqcc.1
@@ -153,7 +153,7 @@ Adds compiler information to the generated binary file. Currently
 this includes the following globals:
 .Bl -tag -width indent -compact
 .It Li reserved:version
-String containing the compiler version as printed by the --version
+String containing the compiler version as printed by the \-\-version
 parameter.
 .El
 .It Fl -correct , Fl -no-correct
@@ -351,7 +351,7 @@ features used in the Xonotic codebase. If you need more, write a
 ticket.
 .It Fl f Ns Cm ftepp-predefs
 Enable some predefined macros. This only works in combination with
-\'-fftepp' and is currently not included by '-std=fteqcc'. The
+\'\-fftepp' and is currently not included by '\-std=fteqcc'. The
 following macros will be added:
 .Bd -literal -offset indent
 __LINE__
@@ -673,7 +673,7 @@ A documented example for a gmqcc.ini file.
 .Sh AUTHOR
 See <http://graphitemaster.github.com/gmqcc>.
 .Sh BUGS
-Currently the '-fftepp-predefs' flag is not included by '-std=fteqcc',
+Currently the '\-fftepp-predefs' flag is not included by '\-std=fteqcc',
 partially because it is not entirely conformant to fteqcc.
 .Pp
 Please report bugs on <http://github.com/graphitemaster/gmqcc/issues>,


### PR DESCRIPTION
Accortding to lintian report:
I: gmqcc: hyphen-used-as-minus-sign usr/share/man/man1/gmqcc.1.gz:156
N:
N:    This manual page seems to contain a hyphen where a minus sign was
N:    intended. By default, "-" chars are interpreted as hyphens (U+2010) by
N:    groff, not as minus signs (U+002D). Since options to programs use minus
N:    signs (U+002D), this means for example in UTF-8 locales that you cannot
N:    cut and paste options, nor search for them easily. The Debian groff
N:    package currently forces "-" to be interpreted as a minus sign due to
N:    the number of manual pages with this problem, but this is a
N:    Debian-specific modification and hopefully eventually can be removed.
N:
N:    "-" must be escaped ("-") to be interpreted as minus. If you really
N:    intend a hyphen (normally you don't), write it as "(hy" to emphasise
N:    that fact. See groff(7) and especially groff_char(7) for details, and
N:    also the thread starting with
N:    http://lists.debian.org/debian-devel/2003/debian-devel-200303/msg01481.html
N:
N:    If you use some tool that converts your documentation to groff format,
N:    this tag may indicate a bug in the tool. Some tools convert dashes of
N:    any kind to hyphens. The safe way of converting dashes is to convert
N:    them to "-".
N:
N:    Because this error can occur very often, Lintian shows only the first 10
N:    occurrences for each man page and give the number of suppressed
N:    occurrences. If you want to see all warnings, run Lintian with the
N:    -d/--debug option.
N:
N:    Refer to /usr/share/doc/groff-base/README.Debian and the groff_char(7)
N:    manual page for details.
N:
N:    Severity: wishlist, Certainty: possible
N:
N:    Check: manpages, Type: binary
N:
I: gmqcc: hyphen-used-as-minus-sign usr/share/man/man1/gmqcc.1.gz:354
I: gmqcc: hyphen-used-as-minus-sign usr/share/man/man1/gmqcc.1.gz:676
