### PR TITLE
Big endian swap fix

### DIFF
--- a/code.c
+++ b/code.c
@@ -260,21 +260,21 @@ static void code_create_header(code_t *code, prog_header_t *code_header, const c
     }
 
     /* ensure all data is in LE format */
-    util_tolittleendian(&code_header->version,              sizeof(code_header->version));
-    util_tolittleendian(&code_header->crc16,                sizeof(code_header->crc16));
-    util_tolittleendian(&code_header->statements.offset,    sizeof(code_header->statements.offset));
-    util_tolittleendian(&code_header->statements.length,    sizeof(code_header->statements.length));
-    util_tolittleendian(&code_header->defs.offset,          sizeof(code_header->defs.offset));
-    util_tolittleendian(&code_header->defs.length,          sizeof(code_header->defs.length));
-    util_tolittleendian(&code_header->fields.offset,        sizeof(code_header->fields.offset));
-    util_tolittleendian(&code_header->fields.length,        sizeof(code_header->fields.length));
-    util_tolittleendian(&code_header->functions.offset,     sizeof(code_header->functions.offset));
-    util_tolittleendian(&code_header->functions.length,     sizeof(code_header->functions.length));
-    util_tolittleendian(&code_header->strings.offset,       sizeof(code_header->strings.offset));
-    util_tolittleendian(&code_header->strings.length,       sizeof(code_header->strings.length));
-    util_tolittleendian(&code_header->globals.offset,       sizeof(code_header->globals.offset));
-    util_tolittleendian(&code_header->globals.length,       sizeof(code_header->globals.length));
-    util_tolittleendian(&code_header->entfield,             sizeof(code_header->entfield));
+    util_endianswap(&code_header->version,              1, sizeof(code_header->version));
+    util_endianswap(&code_header->crc16,                1, sizeof(code_header->crc16));
+    util_endianswap(&code_header->statements.offset,    1, sizeof(code_header->statements.offset));
+    util_endianswap(&code_header->statements.length,    1, sizeof(code_header->statements.length));
+    util_endianswap(&code_header->defs.offset,          1, sizeof(code_header->defs.offset));
+    util_endianswap(&code_header->defs.length,          1, sizeof(code_header->defs.length));
+    util_endianswap(&code_header->fields.offset,        1, sizeof(code_header->fields.offset));
+    util_endianswap(&code_header->fields.length,        1, sizeof(code_header->fields.length));
+    util_endianswap(&code_header->functions.offset,     1, sizeof(code_header->functions.offset));
+    util_endianswap(&code_header->functions.length,     1, sizeof(code_header->functions.length));
+    util_endianswap(&code_header->strings.offset,       1, sizeof(code_header->strings.offset));
+    util_endianswap(&code_header->strings.length,       1, sizeof(code_header->strings.length));
+    util_endianswap(&code_header->globals.offset,       1, sizeof(code_header->globals.offset));
+    util_endianswap(&code_header->globals.length,       1, sizeof(code_header->globals.length));
+    util_endianswap(&code_header->entfield,             1, sizeof(code_header->entfield));
 
     /*
      * These are not part of the header but we ensure LE format here to save on duplicated
@@ -282,36 +282,36 @@ static void code_create_header(code_t *code, prog_header_t *code_header, const c
      */
 
     for (i = 0; i < vec_size(code->statements); ++i) {
-        util_tolittleendian(& code->statements[i].opcode,   sizeof(code->statements[i].opcode));
-        util_tolittleendian(& code->statements[i].o1,       sizeof(code->statements[i].o1));
-        util_tolittleendian(& code->statements[i].o2,       sizeof(code->statements[i].o2));
-        util_tolittleendian(& code->statements[i].o3,       sizeof(code->statements[i].o3));
+        util_endianswap(&code->statements[i].opcode,    1, sizeof(code->statements[i].opcode));
+        util_endianswap(&code->statements[i].o1,        1, sizeof(code->statements[i].o1));
+        util_endianswap(&code->statements[i].o2,        1, sizeof(code->statements[i].o2));
+        util_endianswap(&code->statements[i].o3,        1, sizeof(code->statements[i].o3));
     }
 
     for (i = 0; i < vec_size(code->defs); ++i) {
-        util_tolittleendian(& code->defs[i].type,   sizeof(code->defs[i].type));
-        util_tolittleendian(& code->defs[i].offset, sizeof(code->defs[i].offset));
-        util_tolittleendian(& code->defs[i].name,   sizeof(code->defs[i].name));
+        util_endianswap(&code->defs[i].type,   1, sizeof(code->defs[i].type));
+        util_endianswap(&code->defs[i].offset, 1, sizeof(code->defs[i].offset));
+        util_endianswap(&code->defs[i].name,   1, sizeof(code->defs[i].name));
     }
 
     for (i = 0; i < vec_size(code->fields); ++i) {
-        util_tolittleendian(& code->fields[i].type,   sizeof(code->fields[i].type));
-        util_tolittleendian(& code->fields[i].offset, sizeof(code->fields[i].offset));
-        util_tolittleendian(& code->fields[i].name,   sizeof(code->fields[i].name));
+        util_endianswap(&code->fields[i].type,   1, sizeof(code->fields[i].type));
+        util_endianswap(&code->fields[i].offset, 1, sizeof(code->fields[i].offset));
+        util_endianswap(&code->fields[i].name,   1, sizeof(code->fields[i].name));
     }
 
     for (i = 0; i < vec_size(code->functions); ++i) {
-        util_tolittleendian(& code->functions[i].entry,         sizeof(code->functions[i].entry));
-        util_tolittleendian(& code->functions[i].firstlocal,    sizeof(code->functions[i].firstlocal));
-        util_tolittleendian(& code->functions[i].locals,        sizeof(code->functions[i].locals));
-        util_tolittleendian(& code->functions[i].profile,       sizeof(code->functions[i].profile));
-        util_tolittleendian(& code->functions[i].name,          sizeof(code->functions[i].name));
-        util_tolittleendian(& code->functions[i].file,          sizeof(code->functions[i].file));
-        util_tolittleendian(& code->functions[i].nargs,         sizeof(code->functions[i].nargs));
+        util_endianswap(&code->functions[i].entry,         1, sizeof(code->functions[i].entry));
+        util_endianswap(&code->functions[i].firstlocal,    1, sizeof(code->functions[i].firstlocal));
+        util_endianswap(&code->functions[i].locals,        1, sizeof(code->functions[i].locals));
+        util_endianswap(&code->functions[i].profile,       1, sizeof(code->functions[i].profile));
+        util_endianswap(&code->functions[i].name,          1, sizeof(code->functions[i].name));
+        util_endianswap(&code->functions[i].file,          1, sizeof(code->functions[i].file));
+        util_endianswap(&code->functions[i].nargs,         1, sizeof(code->functions[i].nargs));
         /* Don't swap argsize[] - it's just a byte array, which Quake uses only as such. */
     }
 
-    util_tolittleendianarray(code->globals, vec_size(code->globals), sizeof(int32_t));
+    util_endianswap(code->globals, vec_size(code->globals), sizeof(int32_t));
 
 
     if (!OPTS_OPTION_BOOL(OPTION_QUIET)) {
@@ -445,9 +445,9 @@ bool code_write(code_t *code, const char *filename, const char *lnofile) {
         if (!fp)
             return false;
 
-        util_tolittleendian     (&version,                                     sizeof(version));
-        util_tolittleendianarray(code->linenums,   vec_size(code->linenums),   sizeof(code->linenums[0]));
-        util_tolittleendianarray(code->columnnums, vec_size(code->columnnums), sizeof(code->columnnums[0]));
+        util_endianswap(&version,         1,                          sizeof(version));
+        util_endianswap(code->linenums,   vec_size(code->linenums),   sizeof(code->linenums[0]));
+        util_endianswap(code->columnnums, vec_size(code->columnnums), sizeof(code->columnnums[0]));
 
         if (fs_file_write("LNOF",                          4,                                      1,                          fp) != 1 ||
             fs_file_write(&version,                        sizeof(version),                        1,                          fp) != 1 ||

--- a/gmqcc.h
+++ b/gmqcc.h
@@ -213,11 +213,10 @@ void *stat_mem_allocate  (size_t, size_t, const char *, const char *);
 #define util_isprint(a) (((unsigned)(a)-0x20) < 0x5F)
 #define util_isspace(a) (((a) >= 9 && (a) <= 13) || (a) == ' ')
 
-bool  util_strupper (const char *);
-bool  util_strdigit (const char *);
+bool  util_strupper(const char *);
+bool  util_strdigit(const char *);
 
-void  util_tolittleendianarray  (void *, size_t, unsigned int);
-void  util_tolittleendian       (void *,         unsigned int);
+void  util_endianswap(void *, size_t, unsigned int);
 
 size_t util_strtocmd         (const char *, char *, size_t);
 size_t util_strtononcmd      (const char *, char *, size_t);

--- a/pak.c
+++ b/pak.c
@@ -146,9 +146,9 @@ static pak_file_t *pak_open_read(const char *file) {
     memset         (&pak->header, 0, sizeof(pak_header_t));
     fs_file_read   (&pak->header,    sizeof(pak_header_t), 1, pak->handle);
 
-    util_tolittleendian(&pak->header.magic,  sizeof(pak->header.magic));
-    util_tolittleendian(&pak->header.diroff, sizeof(pak->header.diroff));
-    util_tolittleendian(&pak->header.dirlen, sizeof(pak->header.dirlen));
+    util_endianswap(&pak->header.magic,  1, sizeof(pak->header.magic));
+    util_endianswap(&pak->header.diroff, 1, sizeof(pak->header.diroff));
+    util_endianswap(&pak->header.dirlen, 1, sizeof(pak->header.dirlen));
 
     /*
      * Every PAK file has "PACK" stored as FOURCC data in the
@@ -176,8 +176,8 @@ static pak_file_t *pak_open_read(const char *file) {
         fs_file_read   (&dir,    sizeof(pak_directory_t), 1, pak->handle);
 
         /* Don't translate name - it's just an array of bytes. */
-        util_tolittleendian(&dir.pos, sizeof(dir.pos));
-        util_tolittleendian(&dir.len, sizeof(dir.len));
+        util_endianswap(&dir.pos, 1, sizeof(dir.pos));
+        util_endianswap(&dir.len, 1, sizeof(dir.len));
 
         vec_push(pak->directories, dir);
     }
@@ -218,7 +218,7 @@ static pak_file_t *pak_open_write(const char *file) {
     pak->header.magic = PAK_FOURCC;
 
     /* on BE systems we need to swap the byte order of the FOURCC */
-    util_tolittleendian(&pak->header.magic, sizeof(uint32_t));
+    util_endianswap(&pak->header.magic, 1, sizeof(uint32_t));
 
     /*
      * We need to write out the header since files will be wrote out to

--- a/util.c
+++ b/util.c
@@ -95,7 +95,7 @@ const char *util_instr_str[VINSTR_END] = {
     }
 #endif
 
-void util_tolittleendianarray(void *_data, size_t length, unsigned int typesize) {
+void util_endianswap(void *_data, size_t length, unsigned int typesize) {
 #   if PLATFORM_BYTE_ORDER == -1 /* runtime check */
     if (*((char*)&typesize))
         return;
@@ -121,15 +121,11 @@ void util_tolittleendianarray(void *_data, size_t length, unsigned int typesize)
                 return;
 
             default:
-                con_err ("util_tolittleendianarray: I don't know how to swap a %d byte structure!\n", typesize);
+                con_err ("util_endianswap: I don't know how to swap a %u byte structure!\n", typesize);
                 exit(EXIT_FAILURE); /* please blow the fuck up! */
         }
 #   endif
 #endif
-}
-
-void util_tolittleendian(void *_data, unsigned int typesize) {
-    util_tolittleendianarray(_data, 1, typesize);
 }
 
 /*


### PR DESCRIPTION
Hey, I might have put too much into a commit here, just let me know what you think.  I'm kind of a git noob still and trying to get a feel for how fine-grained commits should be.  Thanks for looking at this!

---

Commit message:
    Big-endian: Byteswap only the field contents when writing progs.dat

```
The previous code swapped not just the fields' contents themselves, but
also field positions within several of the structs, resulting in a
non-working progs.dat when compiled on big endian (ppc in my case).
Swapping on a field-by-field basis now.

Also:
* Addresses weird swap size requests (30+ bytes in one case)

* Take a guess at the right way to log a weird swap request before dying

* Fix swap array length scaling

* Rename the main swap function to reflect its native->little-endian
  purpose.  Figued that was okay because progs.dat is required to be
  always little-endian...

* Add a non-array version of the swap function for convenience
```
