### PR TITLE
Fix number of bytes to be zeroed when spawn entity

### DIFF
--- a/exec.cpp
+++ b/exec.cpp
@@ -212,7 +212,7 @@ static qcint_t prog_spawn_entity(qc_program_t *prog) {
     size_t sz = prog->entitydata.size();
     prog->entitydata.resize(sz + prog->entityfields);
     data = (char*)&prog->entitydata[sz];
-    memset(data, 0, sz * sizeof(qcint_t));
+    memset(data, 0, prog->entityfields * sizeof(qcint_t));
 
     return e;
 }


### PR DESCRIPTION
In `qcvm` when zeroing memory for new entitydata wrong number of bytes used. This leads to crash with the error:`malloc(): invalid size (unsorted)`.

Use `prog->entityfields * sizeof(qcint_t)`
instead of `sz * sizeof(qcint_t)`.

`sz` is the size of the `entitydata` vector which is increased every time new entity spawned. 
`prog->entityfields` is the number of entity fields and the size of the increment of the `entitydata` vector. 

The issue can be reproduced with a simple QC program: 
```
void   (string str, ...)          print     = #1;
string (float val)                ftos      = #2;
entity ()                         spawn     = #3;

.float f1, f2, f3;

void() main = {
    local float ent_num;
    local entity ent;
    ent_num = 0;
    while (ent_num < 10) {
        ent_num = ent_num + 1;
        ent = spawn();
        print("spawned entity: ", ftos(ent_num), "\n");
    }
};
```

The program above is compiled with `gmqcc` and executed with `qcvm`. 

When program `progs.dat` is executed  without the change the output is: 
```
spawned entity: 1
spawned entity: 2
spawned entity: 3
malloc(): invalid size (unsorted)
Aborted (core dumped)
```

When the same `progs.dat` is executed with the change in the PR the output is:
```
spawned entity: 1
spawned entity: 2
spawned entity: 3
spawned entity: 4
spawned entity: 5
spawned entity: 6
spawned entity: 7
spawned entity: 8
spawned entity: 9
spawned entity: 10
```