### PR TITLE
fix small typo found by Debian's lintian

### DIFF
--- a/doc/gmqcc.1
+++ b/doc/gmqcc.1
@@ -298,7 +298,7 @@ or code after a call to a function marked as 'noreturn'.
 Enable some warnings added in order to help debugging in the compiler.
 You won't need this.
 .It Fl W Ns Cm unknown-attribute
-Warn on an unknown attribute. The warning will inlclude only the first
+Warn on an unknown attribute. The warning will include only the first
 token inside the enclosing attribute-brackets. This may change when
 the actual attribute syntax is better defined.
 .It Fl W Ns Cm reserved-names
@@ -455,7 +455,7 @@ Perform early out in logical AND and OR expressions. The final result
 will be either a 0 or a 1, see the next flag for more possibilities.
 .It Fl f Ns Cm perl-logic
 In many languages, logical expressions perform early out in a special
-way: If the left operand of an AND yeilds true, or the one of an OR
+way: If the left operand of an AND yields true, or the one of an OR
 yields false, the complete expression evaluates to the right side.
 Thus
 .Ql true && 5

--- a/gmqcc.ini.example
+++ b/gmqcc.ini.example
@@ -116,7 +116,7 @@
 
 
     #In many languages, logical expressions perform early out in a
-    #special way: If the left operand of an AND yeilds true, or the
+    #special way: If the left operand of an AND yields true, or the
     #one of an OR yields false, the complete expression evaluates to
     #the right side.  Thus ‘true && 5’ evaluates to 5 rather than 1.
 
@@ -527,7 +527,7 @@
     DEBUG = false
 
 
-    #Warn on an unknown attribute. The warning will inlclude only the
+    #Warn on an unknown attribute. The warning will include only the
     #first token inside the enclosing attribute-brackets. This may
     #change when the actual attribute syntax is better defined.
 

--- a/parser.cpp
+++ b/parser.cpp
@@ -843,7 +843,7 @@ static bool parser_sy_apply_operator(parser_t *parser, shunt *sy)
             if (NotSameType(TYPE_FLOAT)) {
                 ast_type_to_string(exprs[0], ty1, sizeof(ty1));
                 ast_type_to_string(exprs[1], ty2, sizeof(ty2));
-                compile_error(ctx, "invalid types used in comparision: %s and %s",
+                compile_error(ctx, "invalid types used in comparison: %s and %s",
                     ty1, ty2);
 
                 return false;

--- a/test.cpp
+++ b/test.cpp
@@ -550,7 +550,7 @@ static void task_template_destroy(task_template_t *tmpl) {
         mem_d(it);
 
     /*
-     * Nullify all the template members otherwise nullptr comparision
+     * Nullify all the template members otherwise nullptr comparison
      * checks will fail if tmpl pointer is reused.
      */
     mem_d(tmpl->tempfilename);


### PR DESCRIPTION
fix "spelling-error-in-binary" reported when packaging gmqcc for Debian