### PR TITLE
fix build on big-endian archs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ GSRCS += util.cpp
 
 # Collect all the source files for QCVM.
 QSRCS := exec.cpp
+QSRCS += conout.cpp
+QSRCS += opts.cpp
 QSRCS += stat.cpp
 QSRCS += util.cpp
 


### PR DESCRIPTION
on big-endian, `util.cpp`  use `con_err(const char*, ...)` on line `#83`, so link on `conout.cpp` & `opts.cpp`
